### PR TITLE
Bugs/clay davis/create tmpdir for user

### DIFF
--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -1,6 +1,6 @@
 test_name "Agent should use environment given by ENC for fetching remote files"
 
-testdir = master.puppet_tmpdir('respect_enc_test')
+testdir = create_tmpdir_for_user master, 'respect_enc_test', 'puppet'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END
 #!#{master['puppetbindir']}/ruby
@@ -33,7 +33,7 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
-    atmp = agent.puppet_tmpdir('respect_enc_test')
+    atmp = create_tmpdir_for_user agent, 'respect_enc_test', 'puppet'
     logger.debug "agent: #{agent} \tagent.tmpdir => #{atmp}"
 
     create_remote_file master, "#{testdir}/different.pp", <<END

--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -37,7 +37,7 @@ if master.is_pe?
 
 else
 
-  testdir = master.puppet_tmpdir('report_submission')
+  testdir = create_tmpdir_for_user master, 'report_submission', 'puppet'
 
   teardown do
     on master, "rm -rf #{testdir}"

--- a/acceptance/tests/security/cve-2013-3567_yaml_deserialization_again.rb
+++ b/acceptance/tests/security/cve-2013-3567_yaml_deserialization_again.rb
@@ -1,6 +1,6 @@
 test_name "CVE-2013-3567 Arbitrary YAML Deserialization"
 
-reportdir = master.puppet_tmpdir('yaml_deserialization')
+reportdir = create_tmpdir_for_user master, 'yaml_deserialization', 'puppet'
 
 dangerous_yaml = "--- !ruby/object:Puppet::Transaction::Report { metrics: { resources: !ruby/object:ERB { src: 'exit 0' } }, logs: [], resource_statuses: [], host: '$(puppet master --configprint certname)' }"
 


### PR DESCRIPTION
Fixes acceptance test failure due to missing host.puppet_tmpdir method.
