### PR TITLE
(PUP-3632) Also install puppet.conf in install.rb

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -455,7 +455,7 @@ end
 # Change directory into the puppet root so we don't get the wrong files for install.
 FileUtils.cd File.dirname(__FILE__) do
   # Set these values to what you want installed.
-  configs = glob(%w{conf/auth.conf})
+  configs = glob(%w{conf/auth.conf conf/puppet.conf})
   bins  = glob(%w{bin/*})
   rdoc  = glob(%w{bin/* lib/**/*.rb README* }).reject { |e| e=~ /\.(bat|cmd)$/ }
   ri    = glob(%w{bin/*.rb lib/**/*.rb}).reject { |e| e=~ /\.(bat|cmd)$/ }


### PR DESCRIPTION
Previously install.rb only installed the auth.conf example, but now that
puppet.conf has moved into conf/, that also needs to be installed via
install.rb. This commit adds puppet.conf to the list of configfile to be
installed.