### PR TITLE
(PUP-3090) Set always_cache_features to true for masters

### DIFF
--- a/conf/puppet.conf
+++ b/conf/puppet.conf
@@ -7,3 +7,6 @@
 
     # Where Puppet PID files are kept.
     rundir=/var/run/puppetlabs
+
+[master]
+    always_cache_features=true


### PR DESCRIPTION
always_cache_features allows the master to avoid calling
Gem.clear_paths, which is an expensive operation. This setting defaults
to false for agents, because they may have features that become
available during their run, but for masters this shouldn't be a concern.