### PR TITLE
(PUP-3632) Update paths in AIO init scripts and logrotate configs

### DIFF
--- a/ext/debian/puppet.init
+++ b/ext/debian/puppet.init
@@ -8,8 +8,8 @@
 # Default-Stop:      0 1 6
 ### END INIT INFO
 
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/bin/puppet
+PATH=/opt/puppetlabs/agent/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/opt/puppetlabs/agent/bin/puppet
 DAEMON_OPTS=""
 NAME="agent"
 PROCNAME="puppet"

--- a/ext/debian/puppet.logrotate
+++ b/ext/debian/puppet.logrotate
@@ -1,4 +1,4 @@
-/var/log/puppet/*log {
+/var/log/puppetlabs/agent/puppet.log {
   missingok
   sharedscripts
   create 0644 puppet puppet
@@ -6,7 +6,6 @@
   rotate 4
 
   postrotate
-    pkill -USR2 -u puppet -f 'puppet master' || true
     [ -e /etc/init.d/puppet ] && /etc/init.d/puppet reload > /dev/null 2>&1 || true
   endscript
 }

--- a/ext/redhat/client.init
+++ b/ext/redhat/client.init
@@ -13,13 +13,13 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-PATH=/usr/bin:/sbin:/bin:/usr/sbin
+PATH=/opt/puppetlabs/agent/bin:/usr/bin:/sbin:/bin:/usr/sbin
 export PATH
 
 [ -f /etc/sysconfig/puppet ] && . /etc/sysconfig/puppet
 lockfile=${LOCKFILE-/var/lock/subsys/puppet}
 pidfile=${PIDFILE-/var/run/puppetlabs/agent.pid}
-puppetd=${PUPPETD-/usr/bin/puppet}
+puppetd=${PUPPETD-/opt/puppetlabs/agent/bin/puppet}
 RETVAL=0
 
 PUPPET_OPTS="agent "

--- a/ext/redhat/logrotate
+++ b/ext/redhat/logrotate
@@ -1,10 +1,9 @@
-/var/log/puppet/*log {
+/var/log/puppetlabs/agent/puppet.log {
   missingok
   notifempty
   create 0644 puppet puppet
   sharedscripts
   postrotate
-    pkill -USR2 -u puppet -f 'puppet master' || true
     [ -e /etc/init.d/puppet ] && /etc/init.d/puppet reload > /dev/null 2>&1 || true
   endscript
 }

--- a/ext/systemd/puppet.service
+++ b/ext/systemd/puppet.service
@@ -6,7 +6,7 @@ After=basic.target network.target puppetmaster.service
 [Service]
 EnvironmentFile=-/etc/sysconfig/puppetagent
 EnvironmentFile=-/etc/sysconfig/puppet
-ExecStart=/usr/bin/puppet agent $PUPPET_EXTRA_OPTS --no-daemonize
+ExecStart=/opt/puppetlabs/agent/bin/puppet agent $PUPPET_EXTRA_OPTS --no-daemonize
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This changeset updates the Debian and EL init scripts and systemd service 
file with the path to the AIO puppet binary and adds the AIO bin
directory to PATH.

Since the puppet agent log files are moving to /var/log/puppetlabs/agent, 
we also update the Debian and EL logrotate configurations with the new path.
