### PR TITLE
(PUP-3809) Update puppet.conf to only override for master

### DIFF
--- a/conf/puppet.conf
+++ b/conf/puppet.conf
@@ -1,4 +1,4 @@
-[main]
+[master]
     # Where Puppet stores dynamic and growing data.
     vardir=/opt/puppetlabs/agent/cache
 


### PR DESCRIPTION
Previously, puppet.conf had settings under main, which will be used for
all run modes. The overrides are only required for the master runmode,
which will be running as the puppet user and not the root user. This
commit adjusts the section to master to fix this.