### PR TITLE
Add arch back into the rpm section of install_utils

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -185,7 +185,7 @@ module Puppet
             scp_to host, repo_dir, repo_loc
 
             on host, "cp #{repo_loc}/*.repo /etc/yum.repos.d"
-            on host, "find /etc/yum.repos.d/ -name \"*.repo\" -exec sed -i \"s/baseurl\\s*=\\s*http:\\/\\/#{tld}.*$/baseurl=file:\\/\\/\\/root\\/#{project}/\" {} \\;"
+            on host, "find /etc/yum.repos.d/ -name \"*.repo\" -exec sed -i \"s/baseurl\\s*=\\s*http:\\/\\/#{tld}.*$/baseurl=file:\\/\\/\\/root\\/#{project}\\/\" {} \\;"
             on host, "rpm -Uvh --force #{repo_loc}/*.rpm"
 
           when /^(debian|ubuntu)-([^-]+)-(.+)$/


### PR DESCRIPTION
The arch is required for the yum repo installed in install_utils to
function correctly. It was inadvertantly removed in a previous commit.
This commit returns it to the end of the baseurl for the yumrepo config.