### PR TITLE
Add arch to the install_utils repo munging

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -185,7 +185,7 @@ module Puppet
             scp_to host, repo_dir, repo_loc
 
             on host, "cp #{repo_loc}/*.repo /etc/yum.repos.d"
-            on host, "find /etc/yum.repos.d/ -name \"*.repo\" -exec sed -i \"s/baseurl\\s*=\\s*http:\\/\\/#{tld}.*$/baseurl=file:\\/\\/\\/root\\/#{project}\\/\" {} \\;"
+            on host, "find /etc/yum.repos.d/ -name \"*.repo\" -exec sed -i \"s/baseurl\\s*=\\s*http:\\/\\/#{tld}.*$/baseurl=file:\\/\\/\\/root\\/#{project}\\/#{arch}/\" {} \\;"
             on host, "rpm -Uvh --force #{repo_loc}/*.rpm"
 
           when /^(debian|ubuntu)-([^-]+)-(.+)$/


### PR DESCRIPTION
The last commit omitted the arch from the change, which was important
because the repo was still broken without it. This actually adds arch to
the end of the repo munging.